### PR TITLE
Update PointsSolver.ts to ignore commas when guessing player names

### DIFF
--- a/src/PointsSolver.ts
+++ b/src/PointsSolver.ts
@@ -89,7 +89,7 @@ export class PointsSolver {
       this.result.question.players.black,
     ];
     const possibleWords = new Set<string>(
-      strings.map((s) => s.toLowerCase().split(' ')).flat(),
+      strings.map((s) => s.toLowerCase().replace(/,/gm, '').split(' ')).flat(),
     );
     return this.result.answer.player.split(' ')
       .some((word) => possibleWords.has(word.toLowerCase()));


### PR DESCRIPTION
Hi,

This is a great game! But it does have an issue: when guessing a player name, the comparison is made on the full name (last name comma first name) instead of first removing the commas. This PR fixes it.

Thanks!